### PR TITLE
Define common data points

### DIFF
--- a/pkg/telemetry/data_attributes_generated.go
+++ b/pkg/telemetry/data_attributes_generated.go
@@ -13,7 +13,14 @@ import (
 func (d *Data) Attributes() []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 
-	attrs = append(attrs, attribute.Int64("Nodes", d.Nodes))
+	attrs = append(attrs, attribute.String("ProjectName", d.ProjectName))
+	attrs = append(attrs, attribute.String("ProjectVersion", d.ProjectVersion))
+	attrs = append(attrs, attribute.String("ProjectArchitecture", d.ProjectArchitecture))
+	attrs = append(attrs, attribute.String("ClusterID", d.ClusterID))
+	attrs = append(attrs, attribute.String("ClusterVersion", d.ClusterVersion))
+	attrs = append(attrs, attribute.String("ClusterPlatform", d.ClusterPlatform))
+	attrs = append(attrs, attribute.String("DeploymentID", d.DeploymentID))
+	attrs = append(attrs, attribute.Int64("ClusterNodeCount", d.ClusterNodeCount))
 	
 
 	return attrs

--- a/pkg/telemetry/data_attributes_generated.go
+++ b/pkg/telemetry/data_attributes_generated.go
@@ -19,7 +19,7 @@ func (d *Data) Attributes() []attribute.KeyValue {
 	attrs = append(attrs, attribute.String("ClusterID", d.ClusterID))
 	attrs = append(attrs, attribute.String("ClusterVersion", d.ClusterVersion))
 	attrs = append(attrs, attribute.String("ClusterPlatform", d.ClusterPlatform))
-	attrs = append(attrs, attribute.String("DeploymentID", d.DeploymentID))
+	attrs = append(attrs, attribute.String("InstallationID", d.InstallationID))
 	attrs = append(attrs, attribute.Int64("ClusterNodeCount", d.ClusterNodeCount))
 	
 

--- a/pkg/telemetry/exporter.go
+++ b/pkg/telemetry/exporter.go
@@ -11,16 +11,27 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-// Data includes common telemetry data points.
-// FIXME(pleshakov): Define the data points.
-// Currently, only one data point is added, for the only reason that we can make sure the generator
-// generates code for a struct defined in this package.
-// https://github.com/nginxinc/telemetry-exporter/issues/8 will define the actual data points.
+// Data defines common telemetry data points for NGINX Kubernetes-related projects.
 //
 //go:generate go run -tags=generator github.com/nginxinc/telemetry-exporter/cmd/generator -type Data
 type Data struct {
-	// Nodes is a number of nodes.
-	Nodes int64
+	// ProjectName is the name of the project.
+	ProjectName string
+	// ProjectVersion is the version of the project.
+	ProjectVersion string
+	// ProjectArchitecture is the architecture the project. For example, "amd64".
+	ProjectArchitecture string
+	// ClusterID is the unique id of the Kubernetes cluster where the project is installed.
+	// It is the UID of the `kube-system` Namespace.
+	ClusterID string
+	// ClusterVersion is the Kubernetes version of the cluster.
+	ClusterVersion string
+	// ClusterPlatform is the Kubernetes platform of the cluster.
+	ClusterPlatform string
+	// DeploymentID is the unique id of the project installation in the cluster.
+	DeploymentID string
+	// ClusterNodeCount is the number of nodes in the cluster.
+	ClusterNodeCount int64
 }
 
 // Exportable allows exporting telemetry data using the Exporter.

--- a/pkg/telemetry/exporter.go
+++ b/pkg/telemetry/exporter.go
@@ -28,8 +28,8 @@ type Data struct {
 	ClusterVersion string
 	// ClusterPlatform is the Kubernetes platform of the cluster.
 	ClusterPlatform string
-	// DeploymentID is the unique id of the project installation in the cluster.
-	DeploymentID string
+	// InstallationID is the unique id of the project installation in the cluster.
+	InstallationID string
 	// ClusterNodeCount is the number of nodes in the cluster.
 	ClusterNodeCount int64
 }

--- a/pkg/telemetry/exporter.go
+++ b/pkg/telemetry/exporter.go
@@ -19,7 +19,7 @@ type Data struct {
 	ProjectName string
 	// ProjectVersion is the version of the project.
 	ProjectVersion string
-	// ProjectArchitecture is the architecture the project. For example, "amd64".
+	// ProjectArchitecture is the architecture of the project. For example, "amd64".
 	ProjectArchitecture string
 	// ClusterID is the unique id of the Kubernetes cluster where the project is installed.
 	// It is the UID of the `kube-system` Namespace.


### PR DESCRIPTION
### Proposed changes

Problem:
Ensure that our Kubernetes-related projects share common telemetry data points for consistency.

Solution:
- Define common data points.
- Generate Attributes() methods to allow using the type with the Exporter (to implement Exportable interface).

A project that uses the exporter library will also export the defined data type.

CLOSES -- https://github.com/nginxinc/telemetry-exporter/issues/8

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/telemetry-exporter/blob/main/CONTRIBUTING.md)
      guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
