### PR TITLE
Fix typo in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
       interval: daily
 
   - package-ecosystem: gomod
-    directory: "**/*"
+    directories:
+      - "**/*"
     schedule:
       interval: daily
     groups:


### PR DESCRIPTION
### Proposed changes

It's supposed to be `directories` plural when using globs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/telemetry-exporter/blob/main/CONTRIBUTING.md) guide
- [ ] I have proven my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have ensured the README is up to date
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
