### PR TITLE
Add workaround for renovate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
   vars:
     name: Checks and variables
     runs-on: ubuntu-24.04
-    outputs:
-      go_path: ${{ steps.vars.outputs.go_path }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -36,9 +34,18 @@ jobs:
         with:
           go-version: stable
 
-      - name: Output Variables
-        id: vars
-        run: echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
+      # this can be removed once https://github.com/renovatebot/renovate/issues/12999 is implemented
+      - name: Update files for renovate
+        run: |
+          cd tests && go mod tidy && go mod verify
+        if: ${{ github.actor == 'renovate[bot]' }}
+
+      - name: Commit changes
+        id: commit
+        uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
+        with:
+          commit_message: "Update files for renovate"
+        if: ${{ github.actor == 'renovate[bot]' }}
 
       - name: Check if go.mod and go.sum are up to date
         run: go mod tidy && git diff --exit-code -- go.mod go.sum
@@ -74,6 +81,7 @@ jobs:
   functional-tests:
     name: Functional Tests
     runs-on: ubuntu-24.04
+    needs: vars
     steps:
       - name: Checkout Repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
### Proposed changes

Adds a workaround for running `go mod tidy` in the test directory.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/telemetry-exporter/blob/main/CONTRIBUTING.md) guide
- [ ] I have proven my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have ensured the README is up to date
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
